### PR TITLE
Support React Native 0.47 / Refactor others

### DIFF
--- a/Example/ios/Example.xcodeproj/project.pbxproj
+++ b/Example/ios/Example.xcodeproj/project.pbxproj
@@ -947,7 +947,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "export NODE_BINARY=node\n../node_modules/react-native/packager/react-native-xcode.sh";
+			shellScript = "export NODE_BINARY=node\n../node_modules/react-native/scripts/react-native-xcode.sh";
 		};
 		2D02E4CB1E0B4B27006451C7 /* Bundle React Native Code And Images */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/Example/ios/Example.xcodeproj/project.pbxproj
+++ b/Example/ios/Example.xcodeproj/project.pbxproj
@@ -230,6 +230,20 @@
 			remoteGlobalIDString = 58B5119B1A9E6C1200147676;
 			remoteInfo = RCTText;
 		};
+		BD6ADB671FB467AC00C54840 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 146833FF1AC3E56700842450 /* React.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 3D383D3C1EBD27B6005632C8;
+			remoteInfo = "third-party-tvOS";
+		};
+		BD6ADB691FB467AC00C54840 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 146833FF1AC3E56700842450 /* React.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 3D383D621EBD27B9005632C8;
+			remoteInfo = "double-conversion-tvOS";
+		};
 		D02198D71F7A80E300724D20 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 146833FF1AC3E56700842450 /* React.xcodeproj */;
@@ -440,7 +454,9 @@
 				3DAD3EAD1DF850E9000B6D8A /* libjschelpers.a */,
 				3DAD3EAF1DF850E9000B6D8A /* libjschelpers.a */,
 				D02198D81F7A80E300724D20 /* libthird-party.a */,
+				BD6ADB681FB467AC00C54840 /* libthird-party.a */,
 				D02198DA1F7A80E300724D20 /* libdouble-conversion.a */,
+				BD6ADB6A1FB467AC00C54840 /* libdouble-conversion.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -499,6 +515,7 @@
 				00E356EF1AD99517003FC87E /* ExampleTests */,
 				83CBBA001A601CBA00E9B192 /* Products */,
 				D02198DE1F7A89AF00724D20 /* Frameworks */,
+				BD6ADB491FB467AA00C54840 /* Recovered References */,
 			);
 			indentWidth = 2;
 			sourceTree = "<group>";
@@ -513,6 +530,14 @@
 				2D02E4901E0B4A5D006451C7 /* Example-tvOSTests.xctest */,
 			);
 			name = Products;
+			sourceTree = "<group>";
+		};
+		BD6ADB491FB467AA00C54840 /* Recovered References */ = {
+			isa = PBXGroup;
+			children = (
+				5AE9643C8A2C4E7D875DEE27 /* libRNPartyTrack.a */,
+			);
+			name = "Recovered References";
 			sourceTree = "<group>";
 		};
 		D02198BA1F7A80E300724D20 /* Products */ = {
@@ -875,6 +900,20 @@
 			fileType = archive.ar;
 			path = libRCTText.a;
 			remoteRef = 832341B41AAA6A8300B99B32 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		BD6ADB681FB467AC00C54840 /* libthird-party.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libthird-party.a";
+			remoteRef = BD6ADB671FB467AC00C54840 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
+		BD6ADB6A1FB467AC00C54840 /* libdouble-conversion.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = "libdouble-conversion.a";
+			remoteRef = BD6ADB691FB467AC00C54840 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
 		D02198D81F7A80E300724D20 /* libthird-party.a */ = {

--- a/Example/ios/Example.xcodeproj/xcshareddata/xcschemes/Example-tvOS.xcscheme
+++ b/Example/ios/Example.xcodeproj/xcshareddata/xcschemes/Example-tvOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0820"
+   LastUpgradeVersion = "0910"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "NO"
@@ -54,6 +54,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -83,6 +84,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Example/ios/Example.xcodeproj/xcshareddata/xcschemes/Example.xcscheme
+++ b/Example/ios/Example.xcodeproj/xcshareddata/xcschemes/Example.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0620"
+   LastUpgradeVersion = "0910"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "NO"
@@ -54,6 +54,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -83,6 +84,7 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/Example/package.json
+++ b/Example/package.json
@@ -8,7 +8,8 @@
 	},
 	"dependencies": {
 		"react": "16.0.0-alpha.12",
-		"react-native": "0.45.1"
+		"react-native": "0.48.4",
+		"react-native-party-track": "file:../"
 	},
 	"devDependencies": {
 		"babel-jest": "21.0.2",

--- a/android/src/main/java/com/yyoshiki41/RNPartyTrack/RNPartyTrack.java
+++ b/android/src/main/java/com/yyoshiki41/RNPartyTrack/RNPartyTrack.java
@@ -12,7 +12,6 @@ import java.util.List;
 
 public class RNPartyTrack implements ReactPackage {
 
-    @Override
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }

--- a/package.json
+++ b/package.json
@@ -18,8 +18,10 @@
     "android"
   ],
   "homepage": "https://github.com/yyoshiki41/react-native-party-track#readme",
-  "devDependencies": {
-    "react": "16.0.0-alpha.12",
-    "react-native": "^0.48.4"
-  }
+  "files": [
+    "RNPartyTrack",
+    "RNPartyTrack.xcodeproj",
+    "android",
+    "index.js"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
   "homepage": "https://github.com/yyoshiki41/react-native-party-track#readme",
   "devDependencies": {
     "react": "16.0.0-alpha.12",
-    "react-native": "0.45.1"
+    "react-native": "^0.48.4"
   }
 }


### PR DESCRIPTION
React Native 0.47 has Breaking Changes.

> https://github.com/facebook/react-native/releases/tag/v0.47.2

Removed `createJSModules`. This change is backward compatible - same as Sentry.

> https://github.com/getsentry/react-native-sentry/pull/172

Also, Update dependencies and Refactor packages.